### PR TITLE
MidiCCButton構造体内の変数の型誤り修正

### DIFF
--- a/EVMC4U/class/EVMC4Ustructs.cs
+++ b/EVMC4U/class/EVMC4Ustructs.cs
@@ -74,7 +74,7 @@ namespace EVMC4U {
     public struct MidiCCButton
     {
         public int knob;
-        public float active;
+        public int active;
     }
 
     public enum CalibrationState


### PR DESCRIPTION
VMCProtocolの仕様上、MIDI CC Button Inputの第二引数はint型ですが、MidiCCButton構造体内で宣言されている第二引数用の変数がfloat型で宣言されていますので、修正しました。

本構造体は一時的な処理のために使用しており、InputReceiver内の条件分岐そのものは正常に動作していますので、特にクリティカルではないかと思いますが、格納されたデータを再利用・再送信し別のEVMC4Uで受信したところ、MIDI CC Value Inputとして受信してしまい正常動作しませんでしたので、構造体本来の意図した使用方法ではなく申し訳ありませんが、念のためPullRequestいたします。